### PR TITLE
Use python2 to build and run MysticMine.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all:
 	rm -f monorail/ai.c monorail/ai.so
 	rm -rf monorail/data
-	@python setup.py build_ext --inplace
+	@python2 setup.py build_ext --inplace
 	ln -s $(CURDIR)/data/800x600/ monorail/data
 
 help:
@@ -18,7 +18,7 @@ help:
 	@echo " rebuild-all             rebuild everything including all assets"
 
 clean:
-	@python setup.py clean
+	@python2 setup.py clean
 	rm -f MANIFEST
 	rm -f monorail/ai.c monorail/ai.so
 	rm -rf monorail/data
@@ -29,11 +29,11 @@ git-clean:
 	git clean -f
 
 install:
-	@python setup.py install
+	@python2 setup.py install
 
 source: clean
-	@python setup.py sdist
+	@python2 setup.py sdist
 
 rebuild-all: clean
-	@python setup.py build_ext --inplace
-	@python build.py
+	@python2 setup.py build_ext --inplace
+	@python2 build.py

--- a/MysticMine
+++ b/MysticMine
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 try:

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 from os import path


### PR DESCRIPTION
PEP-394 defines that python2 should point to the system's python >= 2 installation, and python3 to the system's python >= 3.

Since many systems nowadays use python3 as the default python (ie: python is a symlink to python3), python2 should explicitly be specified when python < 3 is required.

This pull request updates the build scripts, and MysticMine to use python2 by default, since it's dependecies don't yet work on python3.

Specifically, it'll make MysticMine work unpatched on systems/distributions that use python3 by default.
