### PR TITLE
Avoid a crash after the first diamond level.

### DIFF
--- a/monorail/scenarios.py
+++ b/monorail/scenarios.py
@@ -803,7 +803,8 @@ class Quest:
             if scenario.goal is not None:
                 scenario.goal = int(scenario.goal * skill / 10) * 10
         else:
-            scenario.goal = int(scenario.goal * skill)
+            if scenario.goal is not None:
+                scenario.goal = int(scenario.goal * skill)
 
         return scenario
 


### PR DESCRIPTION
I got this crash after completing the first diamond level:

    Unexpected error: <type 'exceptions.TypeError'>
    Traceback (most recent call last):
      File "/usr/local/bin/MysticMine", line 11, in <module>
        monorail.monorail.main()
      File "/usr/local/lib/python2.7/site-packages/monorail/monorail.py", line 540, in main
        app.run()
      File "/usr/local/lib/python2.7/site-packages/monorail/koon/app.py", line 81, in run
        self.do_tick( self.userinput )
      File "/usr/local/lib/python2.7/site-packages/monorail/monorail.py", line 139, in do_tick
        self.menu.show_level_select()
      File "/usr/local/lib/python2.7/site-packages/monorail/menu.py", line 66, in show_level_select
        self.screen = ScreenLevelSelect( self.game_data )
      File "/usr/local/lib/python2.7/site-packages/monorail/menu.py", line 783, in __init__
        self.scenario = self.game_data.get_quest().create_scenario(self.game_data.skill_level.value)
      File "/usr/local/lib/python2.7/site-packages/monorail/scenarios.py", line 806, in create_scenario
        scenario.goal = int(scenario.goal * skill)
    TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'

With this commit it goes away.