### PR TITLE
Don't import "oldnumeric" from NumPy.

### DIFF
--- a/monorail/koon/gfx.py
+++ b/monorail/koon/gfx.py
@@ -1,7 +1,5 @@
-## Automatically adapted for numpy.oldnumeric Nov 20, 2012 by
-
 import copy
-from numpy.oldnumeric import array
+from numpy import array
 
 import pygame
 


### PR DESCRIPTION
Fixes the game when run with NumPy 1.9.